### PR TITLE
automatic check if constraints are fulfilled

### DIFF
--- a/R/minimize.R
+++ b/R/minimize.R
@@ -14,6 +14,7 @@
 #' @param initial_design initial guess (x0 for nloptr)
 #' @param lower_boundary_design design specifying the lower boundary.
 #' @param upper_boundary_design design specifying the upper boundary
+#' @param check_constraints if TRUE, it is checked if constrains are fulfilled
 #' @param opts options list passed to nloptr
 #' @param ... further optional arguments passed to \code{\link{nloptr}}
 #'
@@ -55,6 +56,7 @@ minimize <- function(
     initial_design,
     lower_boundary_design = get_lower_boundary_design(initial_design),
     upper_boundary_design = get_upper_boundary_design(initial_design),
+    check_constraints = TRUE,
     opts         =  list(
         algorithm   = "NLOPT_LN_COBYLA",
         xtol_rel    = 1e-5,
@@ -95,6 +97,41 @@ minimize <- function(
 
     if (res$status == 5 | res$status == 6)
         warning(res$message)
+    
+    if(check_constraints){
+      new_des <- update(initial_design, res$solution)
+      for(constr in subject_to@unconditional_constraints){
+        if(constr@rhs == 0){
+          if(evaluate(constr@score, new_des) - constr@rhs >= 0.001){
+            warning(sprintf("The following constraint could not be fulfilled: %s (absolute tolerance: %s)",
+                            utils::capture.output(show(constr)), format(0.001)))
+          }
+        }
+        else{
+          if(evaluate(constr@score, new_des) - constr@rhs >= min(0.01 * abs(constr@rhs), 0.49)){
+            warning(sprintf("The following constraint could not be fulfilled: %s (relative tolerance: %s)",
+                            utils::capture.output(show(constr)), format(0.01)))
+          }
+        }
+        
+      }
+      for(constr in subject_to@conditional_constraints){
+        grid <- seq(new_des@c1f, new_des@c1e, length.out = 10)
+        if(constr@rhs == 0){
+          if(any(evaluate(constr@score, new_des, grid) - constr@rhs >= 0.001)){
+            warning(sprintf("The following constraint could not be fulfilled: %s (absolute tolerance: %s)",
+                            utils::capture.output(show(constr)), format(0.001)))
+          }
+        }
+        else{
+          if(any(evaluate(constr@score, new_des, grid) - constr@rhs >= min(0.01 * abs(constr@rhs), 0.49))){
+            warning(sprintf("The following constraint could not be fulfilled: %s (relative tolerance: %s)",
+                            utils::capture.output(show(constr)), format(0.01)))
+          }
+        }
+        
+      }
+    }
 
     res <- list(
         design        = update(initial_design, res$solution),

--- a/man/minimize.Rd
+++ b/man/minimize.Rd
@@ -10,6 +10,7 @@ minimize(
   initial_design,
   lower_boundary_design = get_lower_boundary_design(initial_design),
   upper_boundary_design = get_upper_boundary_design(initial_design),
+  check_constraints = TRUE,
   opts = list(algorithm = "NLOPT_LN_COBYLA", xtol_rel = 1e-05, maxeval = 10000),
   ...
 )
@@ -24,6 +25,8 @@ minimize(
 \item{lower_boundary_design}{design specifying the lower boundary.}
 
 \item{upper_boundary_design}{design specifying the upper boundary}
+
+\item{check_constraints}{if TRUE, it is checked if constrains are fulfilled}
 
 \item{opts}{options list passed to nloptr}
 

--- a/tests/testthat/test_minimize.R
+++ b/tests/testthat/test_minimize.R
@@ -353,3 +353,24 @@ test_that("heuristical initial design works", {
     )
 
 }) # end 'heuristical initial design works'
+
+test_that("constraint checks are working", {
+  init <- TwoStageDesign(25, 0.2, 2.5,
+                         c(80, 77, 70, 61, 50, 36, 25),
+                         c(2.2, 2.1, 1.8, 1.4, 0.9, 0.3, -0.1), order = 7L)
+  
+  expect_warning(
+    opt_design <- minimize(ess, subject_to(toer <= 0.01, pow >= 0.95, cp >= 0.95,
+                                           MaximumSampleSize() <= 70),
+                           initial_design = init, check_constraints = TRUE,
+                           opts = list(algorithm = "NLOPT_LN_COBYLA", xtol_rel = 1e-05, maxeval = 1))
+    
+  )
+  
+  expect_warning(
+    opt_design <- minimize(ess,subject_to(toer <= 0.025, pow >= 0.8, MaximumSampleSize() <= pow,
+                                          cp >= ConditionalSampleSize()),
+                           initial_design = init, check_constraints = TRUE,
+                           opts = list(algorithm = "NLOPT_LN_COBYLA", xtol_rel = 1e-05, maxeval = 1))
+  )
+}) # end 'constraint checks are working'


### PR DESCRIPTION
When the constraints are too restrictive, adoptr cannot find a suitable design. But no warning is returned, so the user does not know whether the returned design does indeed fulfill the constraints. A small example:

```
null        <- PointMassPrior(.0, 1)
alternative <- PointMassPrior(.4, 1)
datadist    <- Normal()
ess   <- ExpectedSampleSize(datadist, alternative)
toer  <- Power(datadist, null)
power <- Power(datadist, alternative)

initial_design <- get_initial_design(.4, 0.025, 0.2, "two-stage", datadist)
incorrect_design <- minimize(ess, subject_to(toer <= 0.025, power >= 0.8, MaximumSampleSize() <= 90), 
                         initial_design = initial_design)

evaluate(toer, incorrect_design$design)
evaluate(power, incorrect_design$design)
```
This could be an issue of the underlying optimization algorithm from the nloptr package.

Thus, it makes sense to provide an additional argument in the minimize-function. This new argument allows to check automatically if all constraints in the optimized design are fulfilled.
