### PR TITLE
 Add chi-squared distribution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Collate:
     DataDistribution.R
     BinomialDistribution.R
     NormalDistribution.R
-    StudentDistribution.R             
+    StudentDistribution.R 
+    ChiSquaredDistribution.R
     Prior.R
     PointMassPrior.R
     ContinuousPrior.R

--- a/R/ChiSquaredDistribution.R
+++ b/R/ChiSquaredDistribution.R
@@ -1,0 +1,185 @@
+#' Chi-Squared data distribution
+#'
+#' Implements a chi-squared distribution. The classes \code{Pearson2xk}
+#' and \code{ZSquared} are subclasses, used in two different situations.
+#' \code{Pearson2xK} is used when testing k groups for homogeneity in
+#' response rates. The null hypothesis is
+#' \ifelse{html}{\out{r<sub>1</sub>}=...=\out{r<sub>k</sub>}}{\eqn{r_1=...=r_k}}, and the
+#' alternative is that there exists a pair of groups with differing rates.
+#' \code{ZSquared} implements the square of a normally distributed random variable
+#' with mean \eqn{\mu} and standard deviation \eqn{\sigma^2}.
+#'
+#' @template DataDistributionTemplate
+#'
+#' @rdname ChiSquaredDataDistribution-class
+#' @exportClass ChiSquared
+setClass("ChiSquared", representation(
+  df  = "numeric",
+  multiplier = "numeric"),
+  contains = "DataDistribution")
+
+
+#' Pearson's chi-squared test for contingency tables
+#'
+#' @include DataDistribution.R
+#'
+#' @rdname Pearson2xK-class
+#' @exportClass Pearson2xK
+setClass("Pearson2xK", contains = "ChiSquared")
+
+
+#' Distribution class of a squared normal distribution
+#'
+#' @include DataDistribution.R
+#'
+#' @rdname ZSquared-class
+#' @exportClass ZSquared
+setClass("ZSquared", contains = "ChiSquared")
+
+
+#' @param df number of degrees of freedom
+#'
+#' @examples
+#' datadist <- ChiSquared(df=4)
+#'
+#' @seealso see \code{\link{probability_density_function}} and
+#'    \code{\link{cumulative_distribution_function}} to evaluate the pdf
+#'    and the cdf, respectively.
+#'
+#' @rdname ChiSquaredDataDistribution-class
+#' @export
+ChiSquared <- function(df) {
+  if (df < 0 || abs(df - round(df)) > sqrt(.Machine$double.eps))
+    stop("The degrees of freedom must be natural numbers.")
+  new("ChiSquared", df = df, multiplier = 1)
+}
+
+
+#' Pearson's chi-squared test for 2 x k contingency tables
+#'
+#' When we test for homogeneity of rates in a k-armed trial with binary endpoints, the test statistic is
+#' chi-squared distributed with \eqn{k-1} degrees of freedom under the null. Under the alternative, the statistic is chi-squared distributed with a
+#' non-centrality parameter \eqn{\lambda}. The function \code{get_tau_Pearson2xk} then computes \eqn{\tau}, such that \eqn{\lambda} is given
+#' as \eqn{n \cdot \tau}, where \eqn{n} is the number of subjects per group. In \code{adoptr}, \eqn{\tau} is used in the same way as \eqn{\theta}
+#' in the case of the normally distributed test statistic.
+#'
+#' @param n_groups number of groups considered for testing procedure
+#'
+#' @examples
+#' pearson <- Pearson2xK(3)
+#'
+#'
+#' @rdname Pearson2xK-class
+#' @export
+Pearson2xK <- function(n_groups) {
+  if (n_groups < 0 || abs(n_groups - round(n_groups)) > sqrt(.Machine$double.eps))
+    stop("The number of groups must be a natural number.")
+  new("Pearson2xK", df = n_groups - 1L, multiplier = 1/n_groups)
+}
+
+#' @param p_vector vector denoting the event rates per group
+#'
+#' @examples
+#' H1 <- PointMassPrior(get_tau_Pearson2xK(c(.3, .25, .4)), 1)
+#'
+#' @rdname Pearson2xK-class
+#'
+#' @export
+get_tau_Pearson2xK <- function(p_vector) {
+  n_groups <- length(p_vector)
+  mean_p <- mean(p_vector)
+  deltas <- p_vector - mean_p
+  tau <- (sum(deltas^2)/n_groups) / (mean_p * (1-mean_p))
+  tau
+}
+
+
+#' Squared normally distributed random variable
+#'
+#' Implementation of \eqn{Z^2}, where \eqn{Z} is normally distributed with mean \eqn{\mu} and variance
+#' \eqn{\sigma^2}. \eqn{Z^2} is chi-squared distributed with \eqn{1} degree of freedom and non-centrality parameter \eqn{(\mu/\sigma)^2}.
+#' The function \code{get_tau_ZSquared} computes the factor \eqn{\tau=(\mu/\sigma)^2}, such that
+#' \eqn{\tau} is the equivalent of \eqn{\theta} in the normally distributed case.
+#' The square of a normal distribution \eqn{Z^2} can be used for two-sided hypothesis testing.
+#'
+#' @param two_armed logical indicating if a two-armed trial is regarded
+#'
+#' @examples
+#' zsquared <- ZSquared(FALSE)
+#'
+#'
+#' @rdname ZSquared-class
+#' @export
+ZSquared <- function(two_armed = TRUE) {
+  new("ZSquared", df = 1L, multiplier = 1L + two_armed)
+}
+
+
+#' @param mu mean of Z
+#' @param sigma standard deviation of Z
+#'
+#' @examples
+#' H1 <- PointMassPrior(get_tau_ZSquared(0.4, 1), 1)
+#'
+#' @rdname ZSquared-class
+#'
+#' @export
+get_tau_ZSquared <- function(mu, sigma = 1){
+  (mu/sigma)^2
+}
+
+
+#' @examples
+#' probability_density_function(Pearson2xK(3), 1, 30, get_tau_Pearson2xK(c(0.3, 0.4, 0.7, 0.2)))
+#' probability_density_function(ZSquared(4), 1, 35, get_tau_ZSquared(0.4))
+#'
+#'
+#' @rdname probability_density_function
+#' @export
+setMethod("probability_density_function", signature("ChiSquared", "numeric", "numeric", "numeric"),
+          function(dist, x, n, theta, ...) {
+            return(stats::dchisq(x, df = dist@df, ncp = n / dist@multiplier * theta))
+          })
+
+
+#' @examples
+#' cumulative_distribution_function(Pearson2xK(3), 1, 30, get_tau_Pearson2xK(c(0.3,0.4,0.7,0.2)))
+#' cumulative_distribution_function(ZSquared(4), 1, 35, get_tau_ZSquared(0.4))
+#'
+#'
+#' @rdname cumulative_distribution_function
+#' @export
+setMethod("cumulative_distribution_function", signature("ChiSquared", "numeric", "numeric", "numeric"),
+          function(dist, x, n, theta, ...) {
+            return(stats::pchisq(x, df = dist@df, ncp = n / dist@multiplier * theta))
+          })
+
+
+#' @param probs vector of probabilities
+#' @rdname ChiSquaredDataDistribution-class
+#' @export
+setMethod("quantile", signature("ChiSquared"),
+          function(x, probs, n, theta, ...) { # must be x to conform with generic
+            return(stats::qchisq(probs, df = x@df, ncp = n / x@multiplier * theta))
+          })
+
+
+
+#' @rdname ChiSquaredDataDistribution-class
+#'
+#' @param object object of class \code{ChiSquared}
+#' @param nsim number of simulation runs
+#' @param seed random seed
+#'
+#' @export
+setMethod("simulate", signature("ChiSquared", "numeric"),
+          function(object, nsim, n, theta, seed = NULL, ...) {
+            if (!is.null(seed)) set.seed(seed)
+            return(stats::rchisq(nsim, df = object@df, ncp = n / object@multiplier * theta))
+          })
+
+setMethod("print", signature('ChiSquared'), function(x, ...) {
+  glue::glue(
+    "{class(x)[1]}<df={x@df}>"
+  )
+})

--- a/R/ChiSquaredDistribution.R
+++ b/R/ChiSquaredDistribution.R
@@ -116,7 +116,7 @@ get_tau_Pearson2xK <- function(p_vector) {
 #' @rdname ZSquared-class
 #' @export
 ZSquared <- function(two_armed = TRUE) {
-  new("ZSquared", df = 1L, multiplier = 1L + two_armed)
+  new("ZSquared", df = 1L, multiplier = 1L + ifelse(two_armed, 1L, 0L))
 }
 
 
@@ -129,7 +129,7 @@ ZSquared <- function(two_armed = TRUE) {
 #' @rdname ZSquared-class
 #'
 #' @export
-get_tau_ZSquared <- function(mu, sigma = 1){
+get_tau_ZSquared <- function(mu, sigma) {
   (mu / sigma)^2
 }
 

--- a/R/ChiSquaredDistribution.R
+++ b/R/ChiSquaredDistribution.R
@@ -57,10 +57,13 @@ ChiSquared <- function(df) {
 
 #' Pearson's chi-squared test for 2 x k contingency tables
 #'
-#' When we test for homogeneity of rates in a k-armed trial with binary endpoints, the test statistic is
-#' chi-squared distributed with \eqn{k-1} degrees of freedom under the null. Under the alternative, the statistic is chi-squared distributed with a
-#' non-centrality parameter \eqn{\lambda}. The function \code{get_tau_Pearson2xk} then computes \eqn{\tau}, such that \eqn{\lambda} is given
-#' as \eqn{n \cdot \tau}, where \eqn{n} is the number of subjects per group. In \code{adoptr}, \eqn{\tau} is used in the same way as \eqn{\theta}
+#' When we test for homogeneity of rates in a k-armed trial with binary endpoints, 
+#' the test statistic is chi-squared distributed with \eqn{k-1} degrees of 
+#' freedom under the null. Under the alternative, the statistic is chi-squared 
+#' distributed with a non-centrality parameter \eqn{\lambda}. 
+#' The function \code{get_tau_Pearson2xk} then computes \eqn{\tau}, such that 
+#' \eqn{\lambda} is given as \eqn{n \cdot \tau}, where \eqn{n} is the number of 
+#' subjects per group. In \code{adoptr}, \eqn{\tau} is used in the same way as \eqn{\theta}
 #' in the case of the normally distributed test statistic.
 #'
 #' @param n_groups number of groups considered for testing procedure
@@ -74,7 +77,7 @@ ChiSquared <- function(df) {
 Pearson2xK <- function(n_groups) {
   if (n_groups < 0 || abs(n_groups - round(n_groups)) > sqrt(.Machine$double.eps))
     stop("The number of groups must be a natural number.")
-  new("Pearson2xK", df = n_groups - 1L, multiplier = 1/n_groups)
+  new("Pearson2xK", df = n_groups - 1L, multiplier = 1 / n_groups)
 }
 
 #' @param p_vector vector denoting the event rates per group
@@ -89,18 +92,20 @@ get_tau_Pearson2xK <- function(p_vector) {
   n_groups <- length(p_vector)
   mean_p <- mean(p_vector)
   deltas <- p_vector - mean_p
-  tau <- (sum(deltas^2)/n_groups) / (mean_p * (1-mean_p))
+  tau <- (sum(deltas^2) / n_groups) / (mean_p * (1 - mean_p))
   tau
 }
 
 
 #' Squared normally distributed random variable
 #'
-#' Implementation of \eqn{Z^2}, where \eqn{Z} is normally distributed with mean \eqn{\mu} and variance
-#' \eqn{\sigma^2}. \eqn{Z^2} is chi-squared distributed with \eqn{1} degree of freedom and non-centrality parameter \eqn{(\mu/\sigma)^2}.
-#' The function \code{get_tau_ZSquared} computes the factor \eqn{\tau=(\mu/\sigma)^2}, such that
-#' \eqn{\tau} is the equivalent of \eqn{\theta} in the normally distributed case.
-#' The square of a normal distribution \eqn{Z^2} can be used for two-sided hypothesis testing.
+#' Implementation of \eqn{Z^2}, where \eqn{Z} is normally distributed with mean 
+#' \eqn{\mu} and variance \eqn{\sigma^2}. \eqn{Z^2} is chi-squared distributed 
+#' with \eqn{1} degree of freedom and non-centrality parameter \eqn{(\mu/\sigma)^2}.
+#' The function \code{get_tau_ZSquared} computes the factor \eqn{\tau=(\mu/\sigma)^2}, 
+#' such that \eqn{\tau} is the equivalent of \eqn{\theta} in the normally 
+#' distributed case. The square of a normal distribution \eqn{Z^2} can be used 
+#' for two-sided hypothesis testing.
 #'
 #' @param two_armed logical indicating if a two-armed trial is regarded
 #'
@@ -125,7 +130,7 @@ ZSquared <- function(two_armed = TRUE) {
 #'
 #' @export
 get_tau_ZSquared <- function(mu, sigma = 1){
-  (mu/sigma)^2
+  (mu / sigma)^2
 }
 
 

--- a/tests/testthat/test_ChiSquaredDistribution.R
+++ b/tests/testthat/test_ChiSquaredDistribution.R
@@ -1,0 +1,141 @@
+context("Chi-Squared distribution")
+
+test_that('constructors work', {
+  
+  expect_true(
+    ChiSquared(df = 10)@multiplier == 1
+  )
+  
+  expect_error(
+    ChiSquared(df = -1)
+  )
+  
+  expect_error(
+    ChiSquared(df = 2.3)
+  )
+  
+  expect_true(
+    Pearson2xK(5)@df == 4
+  )
+  
+  expect_true(
+    Pearson2xK(5)@multiplier == 1 / (Pearson2xK(5)@df + 1)
+  )
+  
+  expect_error(
+    Pearson2xK(-3)
+  )
+  
+  expect_error(
+    Pearson2xK(1.8)
+  )
+  
+  expect_equal(
+    ZSquared()@multiplier, ZSquared()@df + 1
+  )
+  
+  expect_equal(
+    ZSquared(FALSE)@multiplier, ZSquared()@df
+  )
+})
+
+test_that('thetas and ncps are correctly computed', {
+  
+  # theoretical ncp and calculated ncp are equal
+  # Pearson2xK
+  p_vector <- c(0.8, 0.15, 0.3, 0.96)
+  n <- 52
+  dist <- Pearson2xK(length(p_vector))
+  real_ncp <- n / length(p_vector) * (sum((p_vector - mean(p_vector))^2)) /
+    (mean(p_vector) * (1 - mean(p_vector)))
+  ncp_calc <- n / dist@multiplier * get_tau_Pearson2xK(p_vector) * 1 / length(p_vector)
+  
+  expect_equal(ncp_calc, real_ncp)
+  
+  #ZSquared
+  dist2 <- ZSquared(TRUE)
+  mu <- 0.4
+  sigma <- 1.2
+  expect_equal(
+    get_tau_ZSquared(mu, sigma) * n / dist2@multiplier,
+    (sqrt(n / 2) * mu/sigma)^2
+  )
+  
+  dist3 <- ZSquared(FALSE)
+  expect_equal(
+    get_tau_ZSquared(mu, sigma) * n / dist3@multiplier,
+    (sqrt(n) * mu/sigma)^2
+  )
+})
+
+test_that('pdf is defined correctly', {
+  
+  dist <- Pearson2xK(3)
+  x       <- seq(-3, 3, by = .1)
+  n       <- 22
+  p_vec   <- c(0.5, 0.6, 0.7)
+  theta   <- get_tau_Pearson2xK(p_vec)
+  expect_equal(
+    probability_density_function(dist, x, n, theta),
+    stats::dchisq(x, df = 2, ncp = n * (sum((p_vec - mean(p_vec))^2)) /
+                    (mean(p_vec) * (1 - mean(p_vec)))),
+    tolerance = 1e-6, scale = 1)
+})
+
+test_that('cdf is defined correctly', {
+  dist <- Pearson2xK(3)
+  x       <- seq(-3, 3, by = .1)
+  n       <- 22
+  p_vec   <- c(0.5, 0.6, 0.7)
+  theta   <- get_tau_Pearson2xK(p_vec)
+  expect_equal(
+    cumulative_distribution_function(dist, x, n, theta),
+    stats::pchisq(x, df = 2, ncp = n * (sum((p_vec - mean(p_vec))^2)) /
+                    (mean(p_vec) * (1 - mean(p_vec)))),
+    tolerance = 1e-6, scale = 1)
+})
+
+test_that('quantile is defined correctly', {
+  
+  dist <- Pearson2xK(3)
+  x       <- seq(0.1, 1, by = .01)
+  n       <- 22
+  p_vec   <- c(0.5, 0.6, 0.7)
+  theta   <- get_tau_Pearson2xK(p_vec)
+  expect_equal(
+    quantile(dist, x, n, theta),
+    stats::qchisq(x, df = 2, ncp = n * (sum((p_vec - mean(p_vec))^2)) /
+                    (mean(p_vec) * (1 - mean(p_vec)))),
+    tolerance = 1e-6, scale = 1)
+})
+
+test_that('simulate respects seed', {
+  
+  expect_equal(
+    simulate(Pearson2xK(3), 10, 10, 0.2, seed = 42),
+    simulate(Pearson2xK(3), 10, 10, 0.2, seed = 42),
+    tolerance = 1e-6, scale = 1)
+  
+  set.seed(42)
+  
+  expect_true(
+    all(simulate(Pearson2xK(4), 10, 12, 1.1) != simulate(Pearson2xK(4), 10, 12, 1.1)))
+})
+
+test_that("show method", {
+  
+  expect_equal(
+    capture.output(show(Pearson2xK(4))),
+    "Pearson2xK<df=3> "
+  )
+  
+  expect_equal(
+    capture.output(show(ZSquared())),
+    "ZSquared<df=1> "
+  )
+  
+  expect_equal(
+    capture.output(show(ChiSquared(5))),
+    "ChiSquared<df=5> "
+  )
+})


### PR DESCRIPTION
Added the classes "Pearson 2xK" and "ZSquared", which both are subclasses of "ChiSquared". "Pearson2xK" can be used for contingency tables (compare binary response in k arms), "ZSquared" can be used for two-sided test problems.

To be in line with the adoptr style, the functions "get_tau_Pearson2xk" and "get_tau_ZSquared" compute an equivalent parameter for $\theta$.