### PR TITLE
improved get_initial_design() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,7 @@ Collate:
     'constraints.R'
     'minimize.R'
     'regularization.R'
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/optad/adoptr/issues
 URL: https://github.com/optad/adoptr, https://optad.github.io/adoptr/

--- a/R/minimize.R
+++ b/R/minimize.R
@@ -152,54 +152,495 @@ setMethod("print", signature("adoptrOptimizationResult"),
 #'
 #' The optimization method \code{\link{minimize}} requires an initial
 #' design for optimization.
-#' The function \code{get_initial_design} provides an initial guess based on a
-#' fixed design that fulfills constraints on type I error rate and power.
-#' Note that a situation-specific initial design may be much more efficient.
+#' This function provides a variety of possibilities to hand-craft designs that 
+#' fulfill type I error and type II error constraints which may be used as initial designs.
 #'
 #' @param theta the alternative effect size in the normal case, the
 #' rate difference under the alternative in the binomial case
 #' @param alpha maximal type I error rate
-#' @param beta maximale type II error rate
-#' @param type is a two-stage, group-sequential, or one-stage design requried?
+#' @param beta maximal type II error rate
+#' @param type_design type of design
+#' @param type_c2 either linear-decreasing c2-function according to inverse normal 
+#' combination test or constant c2
+#' @param type_n2 design of n2-function
 #' @param dist distribution of the test statistic
+#' @param cf first-stage futility boundary
+#' @param ce first-stage efficacy boundary. Note that specifying this boundary 
+#' implies that the type I error constraint might not be fulfilled anymore
+#' @param info_ratio the ratio between first and second stage sample size
+#' @param slope slope of n2 function
+#' @param weight weight of first stage test statistics in inverse normal combination test
 #' @param order desired integration order
 #' @template dotdotdot
 #'
 #' @details
 #' The distribution of the test statistic is specified by \code{dist}.
 #' The default assumes a two-armed z-test.
-#'
-#' @return An object of class \code{\link{TwoStageDesign}}.
+#' The first stage efficacy boundary and the c2 boundary are chosen as Pocock-boundaries, so either ce=c2
+#' if c2 is constant or ce=c, where the null hypothesis is rejected if w1 Z1+w2 Z2>c.
+#' By specifying ce, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
+#' constraint may not be fulfilled.
+#' IMPORTANT: When using the t-distribution or ANOVA, the design does probably
+#' not keep the type I and type II error, only approximate designs are returned.
 #'
 #' @examples
 #' init <- get_initial_design(
 #'    theta = 0.3,
 #'    alpha = 0.025,
 #'    beta  = 0.2,
-#'    type  = "two-stage",
-#'    dist  = Normal(two_armed = FALSE),
-#'    order = 7L
+#'    type_design="two-stage",
+#'    type_c2="linear_decreasing",
+#'    type_n2="linear_increasing",
+#'    dist=Normal(),
+#'    cf=0.7,
+#'    info_ratio=0.5,
+#'    slope=23,
+#'    weight = 1/sqrt(3)
 #' )
 #'
 #' @export
-get_initial_design <- function(theta, alpha, beta,
-                               type = c("two-stage", "group-sequential", "one-stage"),
-                               dist = Normal(), order = 7L, ...) {
-    type <- match.arg(type)
-    if (alpha <= 0 || alpha >= 1 || beta <= 0 || beta >= 1)
-        stop("alpha and beta must be in (0, 1)!")
-    if (is(dist, "Binomial")) {
-        p_0   <- dist@rate_control + theta / 2
-        theta <- theta / sqrt(p_0 * (1 - p_0))
+get_initial_design <- function(theta,
+                               alpha,
+                               beta,
+                               type_design = c("two-stage", "group-sequential", "one-stage"),
+                               type_c2 = c("linear_decreasing", "constant"),
+                               type_n2 = c("optimal", "constant", "linear_decreasing", "linear_increasing"),
+                               dist = Normal(),
+                               cf,
+                               ce,
+                               info_ratio = 0.5,
+                               slope,
+                               weight = sqrt(info_ratio),
+                               order = 7L,...){
+  
+  # match the inputs
+  type_design <- match.arg(type_design)
+  
+  # overwrite the distributions that depend on n under the null
+  if(is(dist, "Student")){
+    dist <- Normal(two_armed = dist@two_armed)
+  }
+  
+  # default value for n when computing rejection boundaries. Only matters for ANOVA
+  n_H0 <- ifelse(is(dist, "NestedModels"), 30, 1)
+  
+  # check that theta is correct
+  theta2 <- ifelse(is(dist, "Survival"), log(theta), theta)
+  theta_null <- ifelse(is(dist, "Survival"), 1, 0)
+  
+  if(theta2 < 0) stop("Effect size must not be smaller than zero!")
+  
+  # compute cf depending on the current distribution
+  if(missing(cf)){
+    cf <- quantile(dist, 0.5, n_H0, theta_null)
+  }
+  
+  # raise warnings if c2 or n2 are mistakenly specified
+  if(type_design == "group-sequential" || type_design == "one-stage") {
+    if(type_design == "one-stage") {
+      if(!missing(type_c2)) {
+        warning("The type of the c2 function is not relevant for one-stage designs.")
+      }
     }
-    c     <- quantile(dist, 1 - alpha, 1, 0)
-    n     <- floor(2 * (c + quantile(dist, 1 - beta, 1, 0))^2 / theta^2)
-    if (type == "one-stage")
-        return(OneStageDesign(n, c))
-    else if (type == "group-sequential")
-        return(GroupSequentialDesign(n/2, 0, quantile(dist, 1 - alpha/2, 1, 0), n/2, c, order))
-    else if (type == "two-stage")
-        return(TwoStageDesign(n/2, 0, quantile(dist, 1 - alpha/2, 1, 0), n/2, c, order))
+    if(!missing(type_n2)) {
+      warning("The type of the n2 function is not relevant for one-stage or group-sequential designs.")
+    }
+  }
+  
+  type_c2 <- match.arg(type_c2)
+  type_n2 <- match.arg(type_n2)
+  
+  # rename some variables
+  power <- 1 - beta
+  w1 <- weight
+  w2 <- sqrt(1 - w1**2)
+  
+  # check for valid inputs
+  if(any(alpha <= 0, alpha >= 1, beta <= 0, beta >= 1, info_ratio < 0, info_ratio > 1, weight >= 1, weight <= 0)) {
+    stop("alpha, beta, information ratio or weights must be in (0, 1)!")}
+  
+  if(!missing(ce)) {
+    if(ce < cf) {
+      stop("Efficacy boundary must not be smaller than futility boundary!")
+    }
+  }
+  
+  
+  # c2 and n2 type not relevant for one-stage designs, so we first finish that case
+  if(type_design == "one-stage") {
+    ce <- quantile(dist, 1 - alpha, n_H0, theta_null)
+    find_n <- function(n) {
+      (1 - cumulative_distribution_function(dist, ce, n, theta)) - power
+    }
+    n <- stats::uniroot(find_n, interval = c(0, 1000), extendInt = "upX")$root
+    return(OneStageDesign(n, ce))
+  }
+  
+  # case 1: constant c2 function
+  if(type_c2 == "constant") {
+    # we assume ce = c2
+    if(missing(ce)) {
+      find_c <- function(c){
+        integrand_c <- function(z) {
+          (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) *
+            probability_density_function(dist, z, n_H0, theta_null)
+        }
+        (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) +
+          stats::integrate(integrand_c,lower = cf,upper = c)$value - alpha
+      }
+      c2 <- stats::uniroot(find_c, interval = c(cf, 5), extendInt = "yes")$root
+      ce <- c2
+    } else {
+      find_c2 <- function(c) {
+        integrand_c <- function(z) {
+          (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) *
+            probability_density_function(dist, z, n_H0, theta_null)
+        }
+        (1 - cumulative_distribution_function(dist, ce, n_H0, theta_null)) +
+          stats::integrate(integrand_c, lower = cf, upper = ce)$value - alpha
+      }
+      c_try <- try(stats::uniroot(find_c2, interval = c(cf, 5), extendInt = "yes")$root,
+                   silent = TRUE)
+      if("try-error" %in% class(c_try)) {
+        warning("Type I error constraint cannot be fulfilled.")
+        find_c <- function(c) {
+          integrand_c <- function(z) {
+            (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) *
+              probability_density_function(dist, z, n_H0, theta_null)
+          }
+          (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) +
+            stats::integrate(integrand_c, lower = cf, upper = c)$value - alpha
+        }
+        c2 <- stats::uniroot(find_c, interval = c(cf, 5), extendInt = "yes")$root
+      } else {
+        c2 <- stats::uniroot(find_c2, interval = c(cf, 5),extendInt = "yes")$root
+      }
+    }
+  }
+  
+  # case2: linear decreasing c2 function by inverse normal combination
+  if(type_c2 == "linear_decreasing") {
+    # we assume ce=c*, where c* is the boundary for Z*=w_1*Z_1+w_2*Z_2
+    if(missing(ce)) {
+      find_ce <- function(c) {
+        integrand_ce <- function(z) {
+          (1 - cumulative_distribution_function(dist, (c - w1 * z) / sqrt(1 - w1**2), n_H0, theta_null)) *
+            probability_density_function(dist, z, n_H0, theta_null)
+        }
+        (1 - cumulative_distribution_function(dist, c, n_H0, theta_null)) +
+          stats::integrate(integrand_ce, lower = cf, upper = c)$value - alpha
+      }
+      c <- stats::uniroot(find_ce, interval = c(cf, 5), extendInt = "yes")$root
+      ce <- c
+    } else {
+      find_ce <- function(c) {
+        integrand_ce <- function(z) {
+          (1 - cumulative_distribution_function(dist, (c - w1 * z) / sqrt(1 - w1**2), n_H0, theta_null)) *
+            probability_density_function(dist, z, n_H0, theta_null)
+        }
+        (1 - cumulative_distribution_function(dist, ce, n_H0, theta_null)) +
+          stats::integrate(integrand_ce,lower = cf, upper = ce)$value - alpha
+      }
+      c_try <- try(stats::uniroot(find_ce, interval = c(cf, 5), extendInt="yes")$root,
+                   silent = TRUE)
+      if("try-error" %in% class(c_try)) {
+        warning("Type I error constraint cannot be fulfilled.")
+        c <- ce
+      } else {
+        c <- stats::uniroot(find_ce, interval = c(cf, 5), extendInt = "yes")$root}
+    }
+    
+    # we need to evaluate this function at each pivot
+    critical_values <- function(z){
+      (c - w1 * z) / sqrt(1 - w1**2)
+    }
+    oldnodes <- GaussLegendreRule(as.integer(order))$nodes
+    h <- (ce - cf) / 2
+    newnodes <- h * oldnodes + (h + cf)
+    c2 <- sapply(newnodes, critical_values)
+  }
+  
+  # for group-sequential designs, n2 is constant. We choose n so that the toer and tter are not exceeded
+  if(type_design == "group-sequential") {
+    if(type_c2 == "constant") {
+      find_n <- function(n) {
+        integrand_n <- function(z) {
+          (1 - cumulative_distribution_function(dist, c2, (1 - info_ratio) * n, theta)) *
+            probability_density_function(dist, z, (info_ratio) * n, theta)
+        }
+        (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+          stats::integrate(integrand_n, cf, ce)$value - power
+      }
+    }
+    if(type_c2 == "linear_decreasing") {
+      find_n <- function(n) {
+        integrand_n <- function(z) {
+          (1 - cumulative_distribution_function(dist, (c - w1 * z) / sqrt(1 - w1**2), (1 - info_ratio) * n, theta)) *
+            probability_density_function(dist, z, (info_ratio)*n, theta)
+        }
+        (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+          stats::integrate(integrand_n, cf, ce)$value - power
+      }
+    }
+    # choose n1 and n2 according to information ratio
+    n <- stats ::uniroot(find_n, interval = c(0, 1000), extendInt = "upX")$root
+    n1 <- info_ratio * n
+    n2 <- (1-info_ratio) * n
+    # if(length(c2)!=1) n2 <- rep(n2,order)
+    
+    design <-  GroupSequentialDesign(n1, cf, ce, n2, c2, order = order)
+    return(design)
+  }
+  
+  # for two-stage designs, the four different n2-designs need to be considered
+  if(type_design == "two-stage") {
+    # constant n2 is the same as group-sequential, but returns a two-stage instead of a group sequential design
+    if(type_n2 == "constant") {
+      if(type_c2 == "constant") {
+        find_n <- function(n) {
+          integrand_n <- function(z) {
+            (1 - cumulative_distribution_function(dist, c2, (1 - info_ratio) * n, theta)) *
+              probability_density_function(dist, z, (info_ratio) * n, theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+            stats::integrate(integrand_n, cf, ce)$value - power
+        }
+      }
+      if(type_c2 == "linear_decreasing") {
+        find_n <- function(n) {
+          integrand_n <- function(z) {
+            (1 - cumulative_distribution_function(dist, (c - w1 * z) / sqrt(1 - w1**2), (1 - info_ratio) * n, theta)) *
+              probability_density_function(dist, z, (info_ratio) * n, theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+            stats::integrate(integrand_n, cf, ce)$value - power
+        }
+      }
+      # choose n1 and n2 according to information ratio
+      n <- stats ::uniroot(find_n, interval = c(0, 1000), extendInt = "upX")$root
+      n1 <- info_ratio * n
+      n2 <- (1 - info_ratio) * n
+      if(length(c2) != 1) n2 <- rep(n2, order)
+      
+      design <-  TwoStageDesign(n1, cf, ce, n2, c2, order = order)
+      return(design)
+    }
+    
+    # the optimal n2 function is evaluated at each pivot and therefore, it is not constant 
+    # first stage sample size is determined like before.
+    if(any(type_n2 == "optimal", type_n2=="linear_increasing", type_n2=="linear_decreasing")) {
+      if(length(c2) == 1) c2 <- rep(c2,order)
+      
+      if(type_c2 == "constant") {
+        find_n <- function(n) {
+          integrand_n <- function(z) {
+            (1 - cumulative_distribution_function(dist, c2, (1 - info_ratio) * n, theta)) *
+              probability_density_function(dist, z, (info_ratio) * n, theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+            stats::integrate(integrand_n, cf, ce)$value - power
+        }
+      }
+      
+      if(type_c2 == "linear_decreasing") {
+        #first, find the n1 sample size. We use the same sample size as we have under constant n2-function
+        find_n <- function(n) {
+          integrand_n <- function(z) {
+            (1 - cumulative_distribution_function(dist, (c - w1 * z) / sqrt(1 - w1**2), (1 - info_ratio) * n, theta)) *
+              probability_density_function(dist, z, (info_ratio) * n, theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, info_ratio * n, theta)) +
+            stats::integrate(integrand_n, cf, ce)$value - power
+        }
+      }
+      n <- stats ::uniroot(find_n, interval = c(0, 1000), extendInt = "upX")$root
+      n1 <- info_ratio * n
+      
+      # find the right value of the n2 function at each pivot
+      find_n2 <- function(n2, pivot) {
+        integrand_n2 <- function(z) {
+          (1 - cumulative_distribution_function(dist, pivot, n2, theta)) *
+            probability_density_function(dist, z, n1, theta)
+        }
+        (1 - cumulative_distribution_function(dist, ce, n1, theta)) +
+          stats::integrate(integrand_n2, cf, ce)$value - power
+      }
+      n2 <- rep(0.0, order)
+      for(i in (1:order)) {
+        n_try <- suppressWarnings(try(stats::uniroot(f = find_n2,
+                                                     interval = c(0, 1000),
+                                                     extendInt = "upX",
+                                                     pivot = c2[i])$root, 
+                                      silent=TRUE))
+        
+        if("try-error" %in% class(n_try) & type_n2 == "optimal") {
+          stop("Optimal n2 function cannot be calculated. Please reduce efficacy boundary or the information ratio.") # nocov
+        } else if("try-error" %in% class(n_try) & 
+                  (type_n2 == "linear_decreasing" || 
+                   type_n2 == "linear_increasing") & missing(slope)) {
+          stop("Please specify a slope or reduce efficacy boundary or the information ratio.") # nocov
+        } else if("try-error" %in% class(n_try) & 
+                  (type_n2 == "linear_decreasing" || 
+                   type_n2 == "linear_increasing") & !missing(slope)) {
+          n2[i] <- 0.1 # nocov
+        } else {
+          n2[i] <- stats::uniroot(f = find_n2, interval = c(0, 1000), extendInt = "upX",
+                                  pivot = c2[i])$root
+        }
+      }
+      
+      if(type_n2 == "optimal") {
+        design <-  TwoStageDesign(n1, cf, ce, n2, c2)
+        return(design)
+      }
+      
+      if(type_n2 == "linear_decreasing") {
+        interim_design <- TwoStageDesign(n1, cf, ce, n2, c2)
+        if(missing(slope)) {
+          #find the minimum and maximal values of n2
+          n2_min <- n2(interim_design, ce)
+          n2_max <- n2(interim_design, cf)
+          
+          #compute the slope of n2 function
+          slope <- (n2_min - n2_max) / (ce - cf)
+          if(slope == 0) {
+            slope <- -n2_max / (ce - cf) # nocov
+          }
+        }
+        
+        if(slope > 0){
+          stop("For linear_decreasing, slope needs to be smaller zero")
+        }
+        start_value <- -slope * ce + .1
+        
+        #find y-intercept of n2 function
+        find_y_intercept <- function(b, slope ){
+          integrand_b <- function(z) {
+            (1 - cumulative_distribution_function(dist, c2(interim_design, z), slope * z + b, theta)) *
+              probability_density_function(dist,z,n1,theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, n1, theta)) +
+            stats::integrate(integrand_b, cf, ce)$value - power
+        }
+        
+        t <- suppressWarnings(try(stats::uniroot(find_y_intercept,
+                                                 interval = c(start_value, 1000),
+                                                 extendInt = "upX",
+                                                 slope = slope)$root, 
+                                  silent = TRUE))
+        
+        if("try-error" %in% class(t)) {
+          warning("Absolute value of slope too high. It was automatically reduced.")
+        }
+        while(("try-error" %in% class(t))&&(slope<=0)) {
+          slope <- slope + 1
+          start_value <- -slope * ce + .1
+          t <- suppressWarnings(try(stats::uniroot(find_y_intercept,
+                                                   interval = c(start_value, 1000),
+                                                   extendInt = "upX",
+                                                   slope=slope)$root,
+                                    silent = TRUE))
+        }
+        if(slope > 0) {# nocov start
+          design <-  TwoStageDesign(n1, cf, ce, n2, c2)
+          return(design)# nocov end
+        }
+        
+        y_intercept <- stats::uniroot(find_y_intercept,
+                                      interval = c(start_value, 1000),
+                                      extendInt = "upX",slope = slope)$root
+        
+        n2func <- function(z) {
+          slope * z + y_intercept
+        }
+        
+        oldnodes <- GaussLegendreRule(as.integer(order))$nodes
+        h <- (ce - cf) / 2
+        newnodes <- h * oldnodes + (h + cf)
+        
+        #evaluate n2 function at pivots
+        n2 <- n2func(newnodes)
+        design <-  TwoStageDesign(n1, cf, ce, n2, c2)
+        return(design)
+      }
+      
+      if(type_n2 == "linear_increasing") {
+        #find the minimum and maximal values of n2
+        interim_design <- TwoStageDesign(n1, cf, ce, n2, c2)
+        if(missing(slope)){
+          #find the minimum and maximal values of n2
+          n2_min <- n2(interim_design, ce)
+          n2_max <- n2(interim_design, cf)
+          
+          
+          #compute the slope of n2 function
+          slope <- (n2_max - n2_min) / (ce - cf)
+          if(slope == 0) {
+            slope <- n2_max / (ce - cf) # nocov
+          }
+        }
+        if(slope < 0) {
+          stop("For linear_increasing, slope needs to be greater zero")
+        }
+        
+        
+        #find y-intercept of n2 function
+        find_y_intercept <- function(b, slope) {
+          integrand_b <- function(z){
+            (1 - cumulative_distribution_function(dist, c2(interim_design,z), slope * z + b, theta)) *
+              probability_density_function(dist, z, n1, theta)
+          }
+          (1 - cumulative_distribution_function(dist, ce, n1, theta)) +
+            stats::integrate(integrand_b, cf, ce)$value - power
+        }
+        
+        start_value <- -slope * cf + .1
+        
+        #it is possible that the n2 function gets negative what leads to errors,
+        #so we need to reduce the slope to be positive
+        t <- suppressWarnings(try(stats::uniroot(find_y_intercept,
+                                                 interval = c(start_value, 1000),
+                                                 extendInt = "upX",
+                                                 slope = slope)$root, 
+                                  silent = TRUE))
+        
+        if("try-error" %in% class(t)) {
+          warning("Absolute value of slope too high. It was automatically reduced.")
+        }
+        while(("try-error" %in% class(t)) && (slope >= 0)) {
+          slope <- slope - 1
+          start_value <- -slope * cf + .1
+          t <- suppressWarnings(try(stats::uniroot(find_y_intercept,
+                                                   interval = c(start_value, 1000),
+                                                   extendInt = "upX",
+                                                   slope = slope)$root, 
+                                    silent = TRUE))
+        }
+        
+        if(slope < 0) {# nocov start
+          design <-  TwoStageDesign(n1, cf, ce, n2, c2)
+          return(design)# nocov end
+        }
+        
+        y_intercept <- stats::uniroot(find_y_intercept,
+                                      interval = c(start_value, 1000),
+                                      extendInt = "upX", slope = slope)$root
+        
+        n2func <- function(z){
+          slope * z + y_intercept
+        }
+        
+        oldnodes <- GaussLegendreRule(as.integer(order))$nodes
+        h <- (ce - cf) / 2
+        newnodes <- h * oldnodes + (h + cf)
+        
+        #evaluate n2 function at pivots
+        n2 <- n2func(newnodes)
+        design <-  TwoStageDesign(n1, cf, ce, n2, c2)
+        return(design)
+      }
+    }
+  }
 }
 
 

--- a/R/minimize.R
+++ b/R/minimize.R
@@ -176,9 +176,9 @@ setMethod("print", signature("adoptrOptimizationResult"),
 #' @details
 #' The distribution of the test statistic is specified by \code{dist}.
 #' The default assumes a two-armed z-test.
-#' The first stage efficacy boundary and the c2 boundary are chosen as Pocock-boundaries, so either ce=c2
-#' if c2 is constant or ce=c, where the null hypothesis is rejected if w1 Z1+w2 Z2>c.
-#' By specifying ce, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
+#' The first stage efficacy boundary and the \eqn{c2} boundary are chosen as Pocock-boundaries, so either \eqn{c_e=c_2}
+#' if \eqn{c_2} is constant or \eqn{c_e=c}, where the null hypothesis is rejected if \eqn{w_1 Z_1+w_2 Z_2>c}.
+#' By specifying \eqn{ce}, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
 #' constraint may not be fulfilled.
 #' IMPORTANT: When using the t-distribution or ANOVA, the design does probably
 #' not keep the type I and type II error, only approximate designs are returned.
@@ -197,7 +197,9 @@ setMethod("print", signature("adoptrOptimizationResult"),
 #'    slope=23,
 #'    weight = 1/sqrt(3)
 #' )
-#'
+#' 
+#' @return An object of class \code{\link{TwoStageDesign}}.
+#' 
 #' @export
 get_initial_design <- function(theta,
                                alpha,

--- a/man/get_initial_design.Rd
+++ b/man/get_initial_design.Rd
@@ -8,8 +8,15 @@ get_initial_design(
   theta,
   alpha,
   beta,
-  type = c("two-stage", "group-sequential", "one-stage"),
+  type_design = c("two-stage", "group-sequential", "one-stage"),
+  type_c2 = c("linear_decreasing", "constant"),
+  type_n2 = c("optimal", "constant", "linear_decreasing", "linear_increasing"),
   dist = Normal(),
+  cf,
+  ce,
+  info_ratio = 0.5,
+  slope,
+  weight = sqrt(info_ratio),
   order = 7L,
   ...
 )
@@ -20,38 +27,61 @@ rate difference under the alternative in the binomial case}
 
 \item{alpha}{maximal type I error rate}
 
-\item{beta}{maximale type II error rate}
+\item{beta}{maximal type II error rate}
 
-\item{type}{is a two-stage, group-sequential, or one-stage design requried?}
+\item{type_design}{type of design}
+
+\item{type_c2}{either linear-decreasing c2-function according to inverse normal
+combination test or constant c2}
+
+\item{type_n2}{design of n2-function}
 
 \item{dist}{distribution of the test statistic}
+
+\item{cf}{first-stage futility boundary}
+
+\item{ce}{first-stage efficacy boundary. Note that specifying this boundary
+implies that the type I error constraint might not be fulfilled anymore}
+
+\item{info_ratio}{the ratio between first and second stage sample size}
+
+\item{slope}{slope of n2 function}
+
+\item{weight}{weight of first stage test statistics in inverse normal combination test}
 
 \item{order}{desired integration order}
 
 \item{...}{further optional arguments}
 }
-\value{
-An object of class \code{\link{TwoStageDesign}}.
-}
 \description{
 The optimization method \code{\link{minimize}} requires an initial
 design for optimization.
-The function \code{get_initial_design} provides an initial guess based on a
-fixed design that fulfills constraints on type I error rate and power.
-Note that a situation-specific initial design may be much more efficient.
+This function provides a variety of possibilities to hand-craft designs that
+fulfill type I error and type II error constraints which may be used as initial designs.
 }
 \details{
 The distribution of the test statistic is specified by \code{dist}.
 The default assumes a two-armed z-test.
+The first stage efficacy boundary and the c2 boundary are chosen as Pocock-boundaries, so either ce=c2
+if c2 is constant or ce=c, where the null hypothesis is rejected if w1 Z1+w2 Z2>c.
+By specifying ce, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
+constraint may not be fulfilled.
+IMPORTANT: When using the t-distribution or ANOVA, the design does probably
+not keep the type I and type II error, only approximate designs are returned.
 }
 \examples{
 init <- get_initial_design(
    theta = 0.3,
    alpha = 0.025,
    beta  = 0.2,
-   type  = "two-stage",
-   dist  = Normal(two_armed = FALSE),
-   order = 7L
+   type_design="two-stage",
+   type_c2="linear_decreasing",
+   type_n2="linear_increasing",
+   dist=Normal(),
+   cf=0.7,
+   info_ratio=0.5,
+   slope=23,
+   weight = 1/sqrt(3)
 )
 
 }

--- a/man/get_initial_design.Rd
+++ b/man/get_initial_design.Rd
@@ -53,6 +53,9 @@ implies that the type I error constraint might not be fulfilled anymore}
 
 \item{...}{further optional arguments}
 }
+\value{
+An object of class \code{\link{TwoStageDesign}}.
+}
 \description{
 The optimization method \code{\link{minimize}} requires an initial
 design for optimization.
@@ -62,9 +65,9 @@ fulfill type I error and type II error constraints which may be used as initial 
 \details{
 The distribution of the test statistic is specified by \code{dist}.
 The default assumes a two-armed z-test.
-The first stage efficacy boundary and the c2 boundary are chosen as Pocock-boundaries, so either ce=c2
-if c2 is constant or ce=c, where the null hypothesis is rejected if w1 Z1+w2 Z2>c.
-By specifying ce, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
+The first stage efficacy boundary and the \eqn{c2} boundary are chosen as Pocock-boundaries, so either \eqn{c_e=c_2}
+if \eqn{c_2} is constant or \eqn{c_e=c}, where the null hypothesis is rejected if \eqn{w_1 Z_1+w_2 Z_2>c}.
+By specifying \eqn{ce}, it's clear that the boundaries are not Pocock-boundaries anymore, so the type I error
 constraint may not be fulfilled.
 IMPORTANT: When using the t-distribution or ANOVA, the design does probably
 not keep the type I and type II error, only approximate designs are returned.

--- a/tests/testthat/test_minimize.R
+++ b/tests/testthat/test_minimize.R
@@ -24,7 +24,12 @@ opt_os <- minimize(
         pow  >= 1 - beta,
         toer <= alpha
     ),
-    initial_design = get_initial_design(.4, alpha, beta, "one-stage", datadist, order)
+    initial_design = get_initial_design(.4, alpha, beta, "one-stage", dist = datadist, order = order),
+    opts         =  list(
+      algorithm   = "NLOPT_LN_COBYLA",
+      xtol_rel    = 1e-7,
+      maxeval     = 1e6
+    )
 )
 
 opt_gs <- minimize(
@@ -33,10 +38,10 @@ opt_gs <- minimize(
         pow  >= 1 - beta,
         toer <= alpha
     ),
-    initial_design = get_initial_design(.4, alpha, beta, "group-sequential", datadist, order)
+    initial_design = get_initial_design(.4, alpha, beta, "group-sequential", dist = datadist, order = order)
 )
 
-initial_design <- get_initial_design(.4, alpha, beta, "two-stage", datadist, order)
+initial_design <- get_initial_design(.4, alpha, beta, "two-stage", dist = datadist, order = order)
 
 opt_ts <- minimize(
     ess,
@@ -325,35 +330,6 @@ test_that("conditional constraints work", {
 }) # end 'conditional constraints work'
 
 
-
-
-test_that("heuristical initial design works", {
-    expect_error(
-        get_initial_design(.4, .025, .2, "adaptive", Normal(), 6L)
-    )
-
-    expect_error(
-        get_initial_design(.4, 1.025, .2, "two-stage", Normal(), 6L)
-    )
-
-    expect_true(
-        is(get_initial_design(.4, .025, .2, "two-stage", Normal(F), 6L), "TwoStageDesign")
-    )
-
-    expect_true(
-        is(get_initial_design(.4, .025, .2, "group-sequential", Normal(), 6L), "GroupSequentialDesign")
-    )
-
-    expect_true(
-        is(get_initial_design(.4, .025, .2, "one-stage", Normal(), 6L), "OneStageDesign")
-    )
-
-    expect_true(
-        is(get_initial_design(.3, .025, .2, "two-stage", Binomial(.2), 5L), "TwoStageDesign")
-    )
-
-}) # end 'heuristical initial design works'
-
 test_that("constraint checks are working", {
   init <- TwoStageDesign(25, 0.2, 2.5,
                          c(80, 77, 70, 61, 50, 36, 25),
@@ -374,3 +350,191 @@ test_that("constraint checks are working", {
                            opts = list(algorithm = "NLOPT_LN_COBYLA", xtol_rel = 1e-05, maxeval = 1))
   )
 }) # end 'constraint checks are working'
+
+test_that("initial design works", {
+  
+  # test that errors are thrown when giving false input
+  expect_error(
+    get_initial_design(.4, .025, .2, "adaptive", dist = Normal(), order = 6L)
+  )
+  
+  expect_error(
+    get_initial_design(.4, 1.025, .2, "two-stage", dist = Normal(), order = 6L)
+  )
+  
+  expect_error(
+    get_initial_design(-.4, 0.025, .2, "two-stage", dist = Normal(), order = 6L)
+  )
+  
+  # test that correct types of designs are returned under different scenarios
+  expect_true(
+    is(get_initial_design(.4, .025, .2, "two-stage", dist = Normal(F), order = 6L), "TwoStageDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(0.2, .025, .2, "two-stage", type_n2 = "linear_decreasing", 
+                          dist = Binomial(0.4), order = 6L, slope = -10),
+       "TwoStageDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(0.2, .025, .2, "two-stage", dist = Binomial(0.7), order = 6L),
+       "TwoStageDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(0.2, .025, .2, "two-stage", type_n2 = "linear_increasing", 
+                          dist = Binomial(0.4), order = 6L, slope = 10),
+       "TwoStageDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(.4, .025, .2, "group-sequential", dist = Normal(), order = 6L), 
+       "GroupSequentialDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(.4, .025, .2, "group-sequential", dist=Normal(), type_c2 = "constant",
+                          order = 6L), "GroupSequentialDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(.4, .025, .2, "one-stage", dist = Normal(), order = 6L),
+       "OneStageDesign")
+  )
+  
+  expect_true(
+    is(get_initial_design(0.04, 0.05, 0.2, "group-sequential", dist = ANOVA(2)),
+       "GroupSequentialDesign")
+  )
+  
+  expect_error(
+    get_initial_design(0.4, 0.2, 0.8, ce = 1, cf = 2)
+  )
+  
+  
+  # compute example initial design and check its properties
+  init <- get_initial_design(.4, .025, .2, "two-stage", dist = Normal(F), cf = 0.5,
+                             type_c2 = "constant", ce = 2.5)
+  
+  #check values futility boundary
+  expect_equal(
+    init@c1f, 0.5
+  )
+  
+  # check that c2 is constant
+  expect_true(
+    all(init@c2_pivots - init@c2_pivots[1] == rep(0, 7))
+  )
+  
+  #check efficacy boundary
+  expect_equal(
+    init@c1e, 2.5
+  )
+  
+  init2 <- get_initial_design(.4, .025, .2, "two-stage", dist = Normal(T),
+                              type_n2 = "linear_increasing", slope = 20)
+  
+  #check that n2 is increasing
+  expect_false(
+    is.unsorted(init2@n2_pivots)
+  )
+  
+  init2new <- get_initial_design(.4, .025, .2, "two-stage", dist = Normal(T),
+                                 type_n2 = "linear_increasing", info_ratio = 0.3)
+  
+  #check that n2 is increasing
+  expect_false(
+    is.unsorted(init2new@n2_pivots)
+  )
+  #check the slope
+  expect_equal(
+    n2(init2, 1.5) - n2(init2, 0.5), 20
+  )
+  
+  
+  init3 <- get_initial_design(.4, .025, .2, "two-stage", dist = Normal(T),
+                              type_c2 = "constant", info_ratio = 0.2, ce = 2)
+  #check information ratio
+  expect_equal(
+    4 * rep(init3@n1, 7), init3@n2_pivots
+  )
+  
+  #check that student distribution uses normal distribution
+  init4 <- get_initial_design(0.4, 0.025, 0.1, "one-stage", dist = Student())
+  expect_equal(
+    init4@c1e,
+    1.96,
+    tolerance = 1e-3
+  )
+  
+  #check warnings are raised when unnecessarily specifying n2 or c2 type
+  expect_warning(
+    get_initial_design(0.4, 0.025, 0.2, "one-stage", type_c2 = "constant")
+  )
+  expect_warning(
+    get_initial_design(0.4, 0.025, 0.2, "one-stage", type_n2 = "constant")
+  )
+  
+  #check warning when ce is chosen too small
+  expect_warning(
+    get_initial_design(0.4, 0.025, 0.2, "two-stage", type_c2 = "constant", ce = 1)
+  )
+  expect_warning(
+    get_initial_design(0.4, 0.025, 0.2, "two-stage", type_c2 = "linear_decreasing", ce = 1)
+  )
+  
+  #check that ce can be chosen
+  expect_equal(
+    get_initial_design(0.3, 0.025, 0.2, type_c2 = "linear_decreasing", ce = 3)@c1e,
+    3
+  )
+  
+  init5 <- get_initial_design(.4, .025, .2, "two-stage", dist = Normal(F), cf = 0.5, type_n2 = "constant",
+                              type_c2 = "constant", ce = 2.5)
+  
+  #check that c2 is constant
+  expect_true(
+    all(init@c2_pivots-init@c2_pivots[1] == rep(0,7))
+  )
+  
+  #check that c2 is linear decreasing
+  init6 <- get_initial_design(0.4, .025, .2, "two-stage", dist = Normal(), 
+                              cf = 0.5, type_n2 = "constant",
+                              type_c2 = "linear_decreasing")
+  
+  expect_false(
+    is.unsorted(rev(init6@c2_pivots))
+  )
+  
+  #check linear decreasing n2 design
+  init7 <- get_initial_design(0.4, .025, .2, "two-stage", cf = 0.5,
+                              type_n2 = "linear_decreasing")
+  
+  expect_false(
+    is.unsorted(rev(init7@n2_pivots))
+  )
+  
+  expect_error(
+    get_initial_design(0.4, .025, .2, "two-stage", cf = 0.5,
+                       type_n2 = "linear_decreasing", slope = 10)
+  )
+  
+  expect_error(
+    get_initial_design(0.4, .025, .2, "two-stage", cf = 0.5,
+                       type_n2 = "linear_increasing", slope = -10)
+  )
+  
+  
+  #check that slope is automatically adjusted
+  expect_warning(
+    get_initial_design(0.4, .025, .2, "two-stage", cf = 0.5,
+                       type_n2 = "linear_decreasing",slope = -100))
+  
+  expect_warning(
+    get_initial_design(0.4, .025, .2, "two-stage", cf = 0.5,
+                       type_n2 = "linear_increasing",slope = 100))
+  
+  
+  
+}) # end 'initial design works'

--- a/vignettes/adoptr.Rmd
+++ b/vignettes/adoptr.Rmd
@@ -136,7 +136,7 @@ initial_design <- get_initial_design(
   theta = .4,
   alpha = .025,
   beta  = .2,
-  type  = "two-stage",
+  type_design  = "two-stage",
   dist  = datadist,
   order = 7L
 )


### PR DESCRIPTION
Initial designs which are closer to the optimized design lead to better results; the optimization is more likely to return correct results. The improved get_initial_design() can be used to easily handcraft designs with specific properties (e.g. an increasing n_2-function), while it is guaranteed that the function returns designs that fulfill constraints on the type 1 and type 2 error. 