### PR TITLE
Prefer glue_data() when data might be list-ish, not an actual environment

### DIFF
--- a/R/CompositeScore.R
+++ b/R/CompositeScore.R
@@ -27,7 +27,7 @@ setMethod("as_character", signature("CompositeScore"), function(x, ...) {
             str[i] <- sub(names(labels)[j], sprintf("{%s}", names(labels)[j]), str[i])
         }
     }
-    as.character(glue::glue(paste0(str[-1], collapse = "; "), .envir = c(labels, x@non_scores)))
+    as.character(glue::glue_data(c(labels, x@non_scores), paste0(str[-1], collapse = "; ")))
 })
 
 


### PR DESCRIPTION
This PR is inspired by doing revdep checks for glue. The soon-to-be-released `glue::glue()` will error when `.envir` is not an actual environment. `.envir` has always been documented to be an environment and I've been working to make that actually true.

`glue_data()` *does* officially accept something "list-ish" as `.x`. So it is a better choice for your usage.

Backstory in glue:

https://github.com/tidyverse/glue/issues/308
https://github.com/tidyverse/glue/commit/e2b74ff17704261b5a7da25b4ebd2dec94740764
https://github.com/tidyverse/glue/issues/341